### PR TITLE
Add possibility to set user agent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ stamen_watercolor_tiles
 build
 dist
 pyslip.egg-info
+/.env/

--- a/pyslip/__init__.py
+++ b/pyslip/__init__.py
@@ -2,6 +2,6 @@
 # Initialize the pySlip package
 #####
 
-__version__ = '4.0'
+__version__ = '4.0.1'
 
 from pyslip.pyslip import *

--- a/pyslip/open_street_map.py
+++ b/pyslip/open_street_map.py
@@ -52,11 +52,13 @@ class Tiles(tiles_net.Tiles):
     TileWidth = 256
     TileHeight = 256
 
-    def __init__(self, tiles_dir=TilesDir):
+    def __init__(self, tiles_dir=TilesDir, user_agent=None):
         """Override the base class for these tiles.
 
         Basically, just fill in the BaseTiles class with values from above
         and provide the Geo2Tile() and Tile2Geo() methods.
+
+        user_agent - "User-Agent" header value
         """
 
         super().__init__(TileLevels,
@@ -64,7 +66,7 @@ class Tiles(tiles_net.Tiles):
                          tiles_dir=tiles_dir,
                          servers=TileServers, url_path=TileURLPath,
                          max_server_requests=MaxServerRequests,
-                         max_lru=MaxLRU)
+                         max_lru=MaxLRU, user_agent=user_agent)
 # TODO: implement map wrap-around
 #        self.wrap_x = True
 #        self.wrap_y = False


### PR DESCRIPTION
It is related to #61 .

I found similar issue on [OSM forum](https://forum.openstreetmap.org/viewtopic.php?id=68450). It seems that OSM requires valid user agent added to request.

Usage example:

```python
# User agent in format:
# [My program name] [version number] contact [contact@adress.com]
user_agent = 'myApp 4.0.1 contact abuse@example.com'
tiles.Tiles(tiles_dir='osm', user_agent=user_agent)
```
User agent should be unique for each application and doesn't have one valid format. We cannot generate it automatically and developer must to have a possibility to provide it manually.